### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
   createrelease:
     name: Create Release
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: write
     outputs:
       release_url: ${{ steps.release_url.outputs.release_url }}
     steps:
@@ -31,6 +33,8 @@ jobs:
     name: Build packages
     needs: createrelease
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Potential fix for [https://github.com/exxamalte/teams-connex/security/code-scanning/1](https://github.com/exxamalte/teams-connex/security/code-scanning/1)

Add explicit `permissions` blocks at the **job level** so each job gets only what it needs:

- `createrelease` needs to create a release ⇒ `contents: write`.
- `build` needs to checkout source and upload release assets ⇒ `contents: write` (covers both reading repo contents and writing release assets).

This is the safest no-functional-change fix within the shown file. It avoids over-granting globally while ensuring both jobs continue to work.

**File to edit:** `.github/workflows/build.yml`  
**Changes:**
1. Under `createrelease` job (after `runs-on`), add:
   ```yml
   permissions:
     contents: write
   ```
2. Under `build` job (after `runs-on`), add:
   ```yml
   permissions:
     contents: write
   ```

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
