### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
   pull_request: ~
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Python ${{ matrix.python-version }}


### PR DESCRIPTION
Potential fix for [https://github.com/exxamalte/teams-connex/security/code-scanning/5](https://github.com/exxamalte/teams-connex/security/code-scanning/5)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege access by default.

Best fix here (without changing functionality): in `.github/workflows/ci.yaml`, insert:

```yaml
permissions:
  contents: read
```

just below the trigger section (`on:` block) and before `jobs:`. This satisfies CodeQL’s requirement and keeps the workflow behavior intact for checkout/testing/upload steps shown. No imports, methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
